### PR TITLE
Add missing dependency to H5PEditor.RadioGroup

### DIFF
--- a/library.json
+++ b/library.json
@@ -37,6 +37,11 @@
       "machineName": "H5PEditor.ShowWhen",
       "majorVersion": 1,
       "minorVersion": 0
+    },
+    {
+      "machineName": "H5PEditor.RadioGroup",
+      "majorVersion": 1,
+      "minorVersion": 1
     }
   ]
 }

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "Makes it possible to create different shapes.",
   "majorVersion": 1,
   "minorVersion": 1,
-  "patchVersion": 1,
+  "patchVersion": 2,
   "runnable": 0,
   "author": "Joubel",
   "license": "MIT",


### PR DESCRIPTION
When merged in, fixes missing dependency to H5PEditor.RadioGroup.

This seems to have gone unnoticed, because H5P.Shape is only used in H5PEditor.CoursePresentation (and derivatives) where some other dependency loads the radio group widget.

_Please note that it only makes sense to merge this in when this repository becomes the H5P.NDLAShape fork (cmp. https://github.com/NDLA-H5P/h5p-shape)._